### PR TITLE
Pe 14 as a user i can add multiple of the same flowers still save the state positions

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -6,3 +6,14 @@ export type Flower = {
 export type Positions = {
     [x: string]: {x: number, y: number}
 }
+
+export type UseSetItemPositionsArgs = {
+    positions: {
+        state: Positions,
+        setPositions: React.Dispatch<React.SetStateAction<Positions>>
+    },
+    exhibition: {
+        state: Flower[]
+        setExhibitionState: React.Dispatch<React.SetStateAction<Flower[]>>
+    } 
+}

--- a/src/hooks/useSetItemPositions.tsx
+++ b/src/hooks/useSetItemPositions.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { Flower, Positions, UseSetItemPositionsArgs } from "../globals";
+
+const useSetItemPositions = ({
+  positions: { state: positionState, setPositions },
+  exhibition: { state: eState, setExhibitionState },
+}: UseSetItemPositionsArgs) => {
+  useEffect(() => {
+    const existingDivPositions: Positions = JSON.parse(
+      localStorage.getItem("positions_div") as string
+    );
+
+    const existingItemPositions: Flower[] = JSON.parse(
+      localStorage.getItem("items_in_exhibition") as string
+    );
+
+    if (existingDivPositions) {
+      setPositions(existingDivPositions);
+    }
+    if (existingItemPositions) {
+      setExhibitionState(existingItemPositions);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(`positions_div`, JSON.stringify(positionState));
+  }, [positionState]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      `items_in_exhibition`,
+      JSON.stringify(eState)
+    );
+  }, [eState]);
+};
+
+export default useSetItemPositions;

--- a/src/hooks/useSetItemPositions.tsx
+++ b/src/hooks/useSetItemPositions.tsx
@@ -4,7 +4,7 @@ import { Flower, Positions, UseSetItemPositionsArgs } from "../globals";
 const useSetItemPositions = ({
   positions: { state: positionState, setPositions },
   exhibition: { state: eState, setExhibitionState },
-}: UseSetItemPositionsArgs) => {
+}: UseSetItemPositionsArgs): void => {
   useEffect(() => {
     const existingDivPositions: Positions = JSON.parse(
       localStorage.getItem("positions_div") as string


### PR DESCRIPTION
Feature: [Here](https://petunia-exhibition.atlassian.net/jira/software/projects/PE/boards/1?selectedIssue=PE-14)

add unique id to flower before we drag it, & stringify the flower object to parse & set the `exhibitionState` on drop. Handles multiple of the same flower which can be dragged independantly. Abstract `localStorage` to hook & import hook
add type for `useSetItemPositions` args
`useSetItemPositions` - add new hook to abstract logic for setting & saving & updating item positions